### PR TITLE
Fix/85 csrf login form

### DIFF
--- a/assets/js/lib/axiosMiddlewares.js
+++ b/assets/js/lib/axiosMiddlewares.js
@@ -66,19 +66,12 @@ const JwtTokenHeader = function (config) {
 }
 
 const CsrfTokenHeader = function (config) {
-    let meta = getTokenFromMeta()
-
-    switch (config.method.toLowerCase()) {
-        case 'get':
-            if (!config.params) {
-                config.params = {}
-            }
-            config.params[csrfParameter] = meta
-            break;
-        case 'post': // and all other methods throught default
-        default:
-            config.data[csrfParameter] = meta
+    if (config.method.toLowerCase() === 'get') {
+        return config
     }
+
+    let meta = getTokenFromMeta()
+    config.data[csrfParameter] = meta
 
     console.info('axios intercep request', 'csrf', meta)
 

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -45,7 +45,7 @@ security:
             # this guard solve this issue: https://github.com/symfony/symfony/issues/25806
             guard:
                 authenticators:
-                    - App\Security\TokenAuthenticator
+                    - App\Security\CsrfTokenAuthenticator
             #THIS FAILS coz i don't succeed to inject some services (maybe private) and no way to load user
             #simple_preauth:
             #    authenticator: App\Security\ApiKeyAuthenticator

--- a/src/Controller/LoginController.php
+++ b/src/Controller/LoginController.php
@@ -2,9 +2,11 @@
 
 namespace App\Controller;
 
+use App\Security\UserInfo;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
@@ -54,5 +56,29 @@ class LoginController extends Controller
             'token'         => $token,
             'error'         => $error,
         ));
+    }
+
+    /**
+     * This action is the same as LoginJsonController, that's why i extracted quickly the content into a static method (even if a part of developers don't like that)
+     *
+     * @Security("is_granted('IS_AUTHENTICATED_FULLY')")
+     * @Route(
+     *     "/demo/security/login/standard/isloggedin",
+     *     name="demo_secured_page_standard_is_logged_in",
+     *     defaults={"_format"="json"}
+     *     )
+     * @Method({"GET", "POST"})
+     */
+    public function isLoggedIn()
+    {
+        $isGranted = function ($att) {
+            return $this->isGranted($att);
+        };
+
+        $getUser = function () {
+            return $this->getUser();
+        };
+
+        return new JsonResponse(UserInfo::getUserInfo($isGranted, $getUser));
     }
 }

--- a/src/Controller/LoginJsonController.php
+++ b/src/Controller/LoginJsonController.php
@@ -2,6 +2,7 @@
 
 namespace App\Controller;
 
+use App\Security\UserInfo;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
@@ -70,22 +71,18 @@ class LoginJsonController extends Controller
      *     name="demo_secured_page_json_is_logged_in",
      *     defaults={"_format"="json"}
      *     )
-     * @Method({"GET"})
+     * @Method({"GET", "POST"})
      */
     public function isLoggedIn()
     {
-        // will be usefull if we decide to return always 200 + the real Json content represented by isLoggedIn: 0|1
-        $authenticated = $this->isGranted('IS_AUTHENTICATED_FULLY');
-        $data = ['isLoggedIn' => (int)$authenticated, ];
+        $isGranted = function ($att) {
+            return $this->isGranted($att);
+        };
 
-        if ($authenticated) {
-            $user = $this->getUser();
-            $data['me'] = [
-                'username' => $user->getUsername(),
-                'roles' => $user->getRoles(),
-                ];
-        }
+        $getUser = function () {
+            return $this->getUser();
+        };
 
-        return new JsonResponse($data);
+        return new JsonResponse(UserInfo::getUserInfo($isGranted, $getUser));
     }
 }

--- a/src/Security/CsrfToken.php
+++ b/src/Security/CsrfToken.php
@@ -21,9 +21,7 @@ class CsrfToken
      */
     public function getToken($tokenId)
     {
-        $token = $this->tokenManager->getToken($tokenId);
-
-        return $token;
+        return $this->tokenManager->getToken($tokenId);
     }
 
     /**

--- a/src/Security/UserInfo.php
+++ b/src/Security/UserInfo.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Security;
+
+/**
+ * Class UserInfo
+ * @package App\Security
+ */
+class UserInfo
+{
+    /**
+     * @param callable $isGranted
+     * @param callable $getUser
+     * @return array
+     */
+    public static function getUserInfo(callable $isGranted, callable $getUser) {
+        // will be usefull if we decide to return always 200 + the real Json content represented by isLoggedIn: 0|1
+        $authenticated = $isGranted('IS_AUTHENTICATED_FULLY');
+        $data = ['isLoggedIn' => (int)$authenticated, ];
+
+        if ($authenticated) {
+            $user = $getUser();
+            $data['me'] = [
+                'username' => $user->getUsername(),
+                'roles' => $user->getRoles(),
+            ];
+        }
+
+        return $data;
+    }
+}


### PR DESCRIPTION
try to fix #85 

In fact i wonder if this behavior is 'normal'.
I want to use the json_login system from security but i want to add a mandatory CSRF token (like in standard form_login which seems normal to protect the user)
Originally i built the TokenAuthenticator for this, but i missed the fact that this Guard will be used for all routes under the firewall.
In the pattern i had a route isLoggedIn but because it was under the same context it also requires a token which was stupid because it's a GET call.

I still need to add the csrf token in cookie for the js app that are statefull, otherwise it will fail.

I also need to write test case to validate that : 
 * i can log in on both firewall json and standard and use routes from other firewall
 * the CsrfTokenAuthenticator is only used under routes from security_json firewall
 * Call to ApiPlatform are not impacted by tis Guard

Take care that if you have a JSON data from standard_security context then if the call needs authentification, then it will automatically redirect you on standard login_form page (not wished behavior)